### PR TITLE
fix: dev server

### DIFF
--- a/packages/rax-plugin-ssr/package.json
+++ b/packages/rax-plugin-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-plugin-ssr",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "rax ssr plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-plugin-ssr/src/ssr/setDev.js
+++ b/packages/rax-plugin-ssr/src/ssr/setDev.js
@@ -69,8 +69,8 @@ module.exports = (config, context) => {
         process.once('unhandledRejection', (error) => printErrorStack(error, bundleContent));
 
         try {
-          const page = eval(bundleContent); // eslint-disable-line
-          page.render(req, res);
+          const mod = eval(bundleContent); // eslint-disable-line
+          mod.render(req, res);
         } catch (error) {
           printErrorStack(error, bundleContent);
         }

--- a/packages/rax-plugin-ssr/src/ssr/setDev.js
+++ b/packages/rax-plugin-ssr/src/ssr/setDev.js
@@ -69,8 +69,7 @@ module.exports = (config, context) => {
         process.once('unhandledRejection', (error) => printErrorStack(error, bundleContent));
 
         try {
-          const mod = eval(bundleContent); // eslint-disable-line
-          const page = mod.default || mod;
+          const page = eval(bundleContent); // eslint-disable-line
           page.render(req, res);
         } catch (error) {
           printErrorStack(error, bundleContent);


### PR DESCRIPTION
修复 ssr 应用，默认的 dev server 报错。

由于 bundleContent 默认暴露的是一个 render 方法：

```
    export {
      render,
      renderToHTML
    };

    export default render;
```

所以通过原有方式去调用 render 方法，会出现报错。
