### PR TITLE
feat: transfor jsx to html

### DIFF
--- a/packages/rax-plugin-ssr/package.json
+++ b/packages/rax-plugin-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-plugin-ssr",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "rax ssr plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/core": "7.2.0",
     "address": "^1.0.1",
+    "babel-plugin-transform-jsx-to-html": "^0.1.0",
     "error-stack-parser": "^2.0.3",
     "lodash": "^4.17.15",
     "qs": "^6.8.0",

--- a/packages/rax-plugin-ssr/src/ssr/getBase.js
+++ b/packages/rax-plugin-ssr/src/ssr/getBase.js
@@ -20,6 +20,11 @@ module.exports = (context) => {
       .use('babel')
         .tap(options => {
           const res = _.cloneDeep(options);
+          // transfor jsx to html for better ssr performance
+          res.plugins = [
+            require.resolve('babel-plugin-transform-jsx-to-html'),
+            ...options.plugins,
+          ];
           res.presets = options.presets.map(v => {
             if (Array.isArray(v) && v[0].indexOf('@babel/preset-env')) {
               const args = {

--- a/packages/rax-template/package.json
+++ b/packages/rax-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-template",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Rax project template.",
   "files": [
     "template"

--- a/packages/rax-template/template/scaffold/package.json.ejs
+++ b/packages/rax-template/template/scaffold/package.json.ejs
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     <%_ if (projectFeatures.includes('ssr')) { -%>
-    "rax-plugin-ssr": "^0.2.0",
+    "rax-plugin-ssr": "^0.3.0",
     <%_ } -%>
     <%_ if (projectFeatures.includes('serverless')) { -%>
     "rax-plugin-faas": "^0.1.0",

--- a/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
+++ b/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
@@ -16,14 +16,22 @@ function Document(props) {
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover"/>
         <title><%= npmName %></title>
-        {styles.map((src) => <link rel="stylesheet" href={`${publicPath}${src}`} />)}
+        {styles.map((src, index) => <link rel="stylesheet" href={`${publicPath}${src}`} key={`style_${index}`} />)}
       </head>
       <body>
         {/* root container */}
         <div id="root" dangerouslySetInnerHTML={{ __html: initialHtml || '' }} />
         {/* initial data from server side */}
-        <script data-from="server" dangerouslySetInnerHTML={{__html: 'window.__INITIAL_DATA__=' + initialData}} />
-        {scripts.map((src) => <script src={`${publicPath}${src}`} />)}
+        <script data-from="server" dangerouslySetInnerHTML={{__html: 'window.__INITIAL_DATA__=' + initialData}}>
+          {/* eslint-disable-next-line react/react-in-jsx-scope */}
+        </script>
+        {
+          scripts.map(
+            (src, index) => <script src={`${publicPath}${src}`} key={`script_${index}`}>
+              {/* eslint-disable-next-line react/react-in-jsx-scope */}
+            </script>
+          )
+        }
       </body>
     </html>
   );
@@ -41,12 +49,16 @@ function Document(props) {
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,viewport-fit=cover"/>
         <title><%= npmName %></title>
-        {styles.map((src) => <link rel="stylesheet" href={`${publicPath}${src}`} />)}
+        {styles.map((src, key) => <link rel="stylesheet" href={`${publicPath}${src}`} key={`style_${index}`} />)}
       </head>
       <body>
         {/* root container */}
         <div id="root" />
-        {scripts.map((src) => <script src={`${publicPath}${src}`} />)}
+        {scripts.map(
+          (src, index) => <script src={`${publicPath}${src}`} key={`script_${index}`}>
+            {/* eslint-disable-next-line react/react-in-jsx-scope */}
+          </script>
+        )}
       </body>
     </html>
   );

--- a/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
+++ b/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
@@ -28,7 +28,7 @@ function Document(props) {
         {
           scripts.map(
             (src, index) => <script src={`${publicPath}${src}`} key={`script_${index}`}>
-              {/* eslint-disable-next-line react/react-in-jsx-scope */}
+              {/* self-closing script element will not work in HTML */}
             </script>
           )
         }
@@ -56,7 +56,7 @@ function Document(props) {
         <div id="root" />
         {scripts.map(
           (src, index) => <script src={`${publicPath}${src}`} key={`script_${index}`}>
-            {/* eslint-disable-next-line react/react-in-jsx-scope */}
+            {/* self-closing script element does will work in HTML */}
           </script>
         )}
       </body>

--- a/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
+++ b/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
@@ -23,8 +23,6 @@ function Document(props) {
         <div id="root" dangerouslySetInnerHTML={{ __html: initialHtml || '' }} />
         {/* initial data from server side */}
         <script data-from="server" dangerouslySetInnerHTML={{__html: 'window.__INITIAL_DATA__=' + initialData}} />
-          {/* eslint-disable-next-line react/react-in-jsx-scope */}
-        </script>
         {
           scripts.map(
             (src, index) => <script src={`${publicPath}${src}`} key={`script_${index}`}>

--- a/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
+++ b/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
@@ -22,7 +22,7 @@ function Document(props) {
         {/* root container */}
         <div id="root" dangerouslySetInnerHTML={{ __html: initialHtml || '' }} />
         {/* initial data from server side */}
-        <script data-from="server" dangerouslySetInnerHTML={{__html: 'window.__INITIAL_DATA__=' + initialData}}>
+        <script data-from="server" dangerouslySetInnerHTML={{__html: 'window.__INITIAL_DATA__=' + initialData}} />
           {/* eslint-disable-next-line react/react-in-jsx-scope */}
         </script>
         {

--- a/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
+++ b/packages/rax-template/template/scaffold/src/document/index.jsx.ejs
@@ -54,7 +54,7 @@ function Document(props) {
         <div id="root" />
         {scripts.map(
           (src, index) => <script src={`${publicPath}${src}`} key={`script_${index}`}>
-            {/* self-closing script element does will work in HTML */}
+            {/* self-closing script element will not work in HTML */}
           </script>
         )}
       </body>


### PR DESCRIPTION
1. SSR 工程默认引入 babel-plugin-transform-jsx-to-html  插件，进行预编译 JSX 
2. Document 中，修复 script 标签闭合，JS 未被执行的问题