### PR TITLE
fix: app shell plugin use wrong platformLoader env

### DIFF
--- a/packages/rax-plugin-app/package.json
+++ b/packages/rax-plugin-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-plugin-app",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "rax app base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",


### PR DESCRIPTION
rax-compile-config platformLoader will translate universal-env
@example isWeb=true 

before:
import { isWeb, isWeex } from 'universal-env';
         
after:
const isWeb = true;
const isWeex = false
          
App shell will be rendered with Node.js, Some code in wrong environment will throw error.
Find platformLoader 'web' env and translate to the right environment 'node'