### PR TITLE
feat: use default host localhost for dev

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@babel/core": "7.2.0",
-    "address": "^1.0.1",
     "autoprefixer": "^9.4.3",
     "babel-loader": "8.0.4",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",

--- a/packages/build-plugin-rax-app/src/config/user/keys/devServer.js
+++ b/packages/build-plugin-rax-app/src/config/user/keys/devServer.js
@@ -1,5 +1,3 @@
-const address = require('address');
-
 module.exports = {
   defaultValue: {
     compress: true,
@@ -8,7 +6,6 @@ module.exports = {
     hot: true,
     quiet: true,
     overlay: false,
-    host: address.ip(),
     port: 9999,
   },
   validation: 'object',

--- a/packages/build-plugin-rax-component/package.json
+++ b/packages/build-plugin-rax-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-component",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "rax component base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",
@@ -11,7 +11,6 @@
     "rax": "^1.0.0"
   },
   "dependencies": {
-    "address": "^1.0.1",
     "babel-loader": "8.0.4",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^2.4.2",

--- a/packages/build-plugin-rax-component/src/config/user/default.config.js
+++ b/packages/build-plugin-rax-component/src/config/user/default.config.js
@@ -1,5 +1,3 @@
-const address = require('address');
-
 module.exports = {
   outputDir: 'lib',
   devOutputDir: 'lib',
@@ -14,7 +12,6 @@ module.exports = {
     hot: true,
     quiet: true,
     overlay: false,
-    host: address.ip(),
     port: 9999,
   },
 };

--- a/packages/build-plugin-rax-component/src/config/user/keys/devServer.js
+++ b/packages/build-plugin-rax-component/src/config/user/keys/devServer.js
@@ -1,5 +1,3 @@
-const address = require('address');
-
 module.exports = {
   defaultValue: {
     compress: true,
@@ -8,7 +6,6 @@ module.exports = {
     hot: true,
     quiet: true,
     overlay: false,
-    host: address.ip(),
     port: 9999,
   },
   validation: 'object',


### PR DESCRIPTION
为了能够使用 localhost、127.0.0.1 启动本地调试服务，把默认的 ip 配置去掉。
默认使用 0.0.0.0 同时支持 localhost、127.0.0.1 以及 ip 方案