### PR TITLE
Feat use 'IP address' instead of 'localhost' in Weex App

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {
@@ -13,8 +13,8 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "rax": "^1.0.0",
-    "@alib/build-scripts": "^0.1.0"
+    "@alib/build-scripts": "^0.1.0",
+    "rax": "^1.0.0"
   },
   "dependencies": {
     "@babel/core": "7.2.0",
@@ -28,6 +28,7 @@
     "deepmerge": "^4.0.0",
     "fs-extra": "^8.1.0",
     "image-source-loader": "^0.6.5",
+    "ip": "^1.1.5",
     "jsx2mp-cli": "^0.2.0",
     "klaw-sync": "^6.0.0",
     "less": "^3.9.0",

--- a/packages/build-plugin-rax-app/src/dev.js
+++ b/packages/build-plugin-rax-app/src/dev.js
@@ -113,9 +113,14 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, getValue, onHook 
 
     if (targets.includes(WEEX)) {
       // Use Weex App to scan ip address (mobile phone can't visit localhost).
-      const weexUrl = `${devUrl}weex/index.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function () {
+      const weexUrl = `${devUrl}weex/index.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function (match) {
         // Called when matched
-        return `http://${ip.address()}`;
+        try {
+          return `http://${ip.address()}`;
+        } catch (error) {
+          console.log(chalk.yellow(`Get local IP address failed: ${error.toString()}`));
+          return match;
+        }
       });
       console.log(chalk.green('[Weex] Development server at:'));
       console.log('   ', chalk.underline.white(weexUrl));

--- a/packages/build-plugin-rax-app/src/dev.js
+++ b/packages/build-plugin-rax-app/src/dev.js
@@ -1,3 +1,4 @@
+const ip = require('ip');
 const chalk = require('chalk');
 const consoleClear = require('console-clear');
 const qrcode = require('qrcode-terminal');
@@ -111,7 +112,8 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, getValue, onHook 
     }
 
     if (targets.includes(WEEX)) {
-      const weexUrl = `${devUrl}weex/index.js?wh_weex=true`;
+      // Use Weex App to scan ip address (mobile phone can't visit localhost).
+      const weexUrl = `${devUrl.replace(/^http:\/\/localhost/gi, () => `http://${ip.address()}`)}weex/index.js?wh_weex=true`;
       console.log(chalk.green('[Weex] Development server at:'));
       console.log('   ', chalk.underline.white(weexUrl));
       console.log();

--- a/packages/build-plugin-rax-app/src/dev.js
+++ b/packages/build-plugin-rax-app/src/dev.js
@@ -113,7 +113,10 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, getValue, onHook 
 
     if (targets.includes(WEEX)) {
       // Use Weex App to scan ip address (mobile phone can't visit localhost).
-      const weexUrl = `${devUrl.replace(/^http:\/\/localhost/gi, () => `http://${ip.address()}`)}weex/index.js?wh_weex=true`;
+      const weexUrl = `${devUrl}weex/index.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function () {
+        // Called when matched
+        return `http://${ip.address()}`;
+      });
       console.log(chalk.green('[Weex] Development server at:'));
       console.log('   ', chalk.underline.white(weexUrl));
       console.log();

--- a/packages/build-plugin-rax-component/package.json
+++ b/packages/build-plugin-rax-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-component",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "rax component base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",
@@ -25,6 +25,7 @@
     "gulp-typescript": "^5.0.1",
     "html-webpack-plugin": "^3.2.0",
     "image-source-loader": "^0.6.5",
+    "ip": "^1.1.5",
     "jsx2mp-cli": "^0.2.0",
     "klaw-sync": "^6.0.0",
     "less": "^3.9.0",

--- a/packages/build-plugin-rax-component/src/dev.js
+++ b/packages/build-plugin-rax-component/src/dev.js
@@ -114,9 +114,14 @@ module.exports = (api, options = {}) => {
 
       demos.forEach((demo) => {
         // Use Weex App to scan ip address (mobile phone can't visit localhost).
-        const weexUrl = `${devUrl}/weex/${demo.name}.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function () {
+        const weexUrl = `${devUrl}/weex/${demo.name}.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function (match) {
           // Called when matched
-          return `http://${ip.address()}`;
+          try {
+            return `http://${ip.address()}`;
+          } catch (error) {
+            console.log(chalk.yellow(`Get local IP address failed: ${error.toString()}`));
+            return match;
+          }
         });
         console.log('   ', chalk.underline.white(weexUrl));
         console.log();

--- a/packages/build-plugin-rax-component/src/dev.js
+++ b/packages/build-plugin-rax-component/src/dev.js
@@ -114,7 +114,10 @@ module.exports = (api, options = {}) => {
 
       demos.forEach((demo) => {
         // Use Weex App to scan ip address (mobile phone can't visit localhost).
-        const weexUrl = `${devUrl.replace(/^http:\/\/localhost/gi, () => `http://${ip.address()}`)}/weex/${demo.name}.js?wh_weex=true`;
+        const weexUrl = `${devUrl}weex/index.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function () {
+          // Called when matched
+          return `http://${ip.address()}`;
+        });
         console.log('   ', chalk.underline.white(weexUrl));
         console.log();
         qrcode.generate(weexUrl, { small: true });

--- a/packages/build-plugin-rax-component/src/dev.js
+++ b/packages/build-plugin-rax-component/src/dev.js
@@ -1,3 +1,4 @@
+const ip = require('ip');
 const consoleClear = require('console-clear');
 const qrcode = require('qrcode-terminal');
 const chalk = require('chalk');
@@ -112,7 +113,8 @@ module.exports = (api, options = {}) => {
       console.log(chalk.green('[Weex] Development server at:'));
 
       demos.forEach((demo) => {
-        const weexUrl = `${devUrl}/weex/${demo.name}.js?wh_weex=true`;
+        // Use Weex App to scan ip address (mobile phone can't visit localhost).
+        const weexUrl = `${devUrl.replace(/^http:\/\/localhost/gi, () => `http://${ip.address()}`)}/weex/${demo.name}.js?wh_weex=true`;
         console.log('   ', chalk.underline.white(weexUrl));
         console.log();
         qrcode.generate(weexUrl, { small: true });

--- a/packages/build-plugin-rax-component/src/dev.js
+++ b/packages/build-plugin-rax-component/src/dev.js
@@ -114,7 +114,7 @@ module.exports = (api, options = {}) => {
 
       demos.forEach((demo) => {
         // Use Weex App to scan ip address (mobile phone can't visit localhost).
-        const weexUrl = `${devUrl}weex/index.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function () {
+        const weexUrl = `${devUrl}/weex/${demo.name}.js?wh_weex=true`.replace(/^http:\/\/localhost/gi, function () {
           // Called when matched
           return `http://${ip.address()}`;
         });


### PR DESCRIPTION
We use Weex App to scan QRCode debug Weex page.
Mobile phone can't visit url like http://localhost:3333/weex/index.js?wh_weex=true.

Change http://localhost:3333/weex/index.js?wh_weex=true to http://xx.xx.xx.xx:3333/weex/index.js?wh_weex=true