### PR TITLE
fix: return styles when there is styles in webpack output

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
+++ b/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
@@ -93,7 +93,7 @@ module.exports = class UniversalDocumentPlugin {
         const DocumentContextProvider = function () { };
         DocumentContextProvider.prototype.getChildContext = function () {
           return {
-            __styles: isMultiple ? assets.styles : [],  // In SPA, css files is loaded by app-loader dynamicly based on path 
+            __styles: assets.styles,
             __scripts: assets.scripts,
           };
         };

--- a/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
+++ b/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
@@ -184,6 +184,6 @@ function getAssetsForPage(files, publicPath) {
 
   return {
     scripts: jsFiles.map(script => publicPath + script),
-    styles: cssFiles.map(script => publicPath + script),
+    styles: cssFiles.map(style => publicPath + style),
   };
 }

--- a/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
+++ b/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
@@ -93,7 +93,7 @@ module.exports = class UniversalDocumentPlugin {
         const DocumentContextProvider = function () { };
         DocumentContextProvider.prototype.getChildContext = function () {
           return {
-            __styles: isMultiple ? assets.styles : [],
+            __styles: isMultiple ? assets.styles : [],  // In SPA, css files is loaded by app-loader dynamicly based on path 
             __scripts: assets.scripts,
           };
         };
@@ -175,23 +175,15 @@ function loadDocument(content, insertScript) {
 
 /**
  * get assets from webpack outputs
- * @param {*} files 
+ * @param {*} files [ 'web/detail.css', 'web/detail.js' ]
  * @param {*} publicPath 
  */
 function getAssetsForPage(files, publicPath) {
-  const fileNames = files.filter(v => ~v.indexOf('.js'));
-
-  const styles = [];
-  if (fileNames && fileNames[0]) {
-    // get the css file name by the entry bundle name
-    const styleFileName = fileNames[0].replace('.js', '.css');
-    styles.push(publicPath + styleFileName);
-  }
-
-  const scripts = fileNames.map(script => publicPath + script);
+  const jsFiles = files.filter(v => ~v.indexOf('.js'));
+  const cssFiles = files.filter(v => ~v.indexOf('.css'));
 
   return {
-    scripts,
-    styles,
+    scripts: jsFiles.map(script => publicPath + script),
+    styles: cssFiles.map(script => publicPath + script),
   };
 }

--- a/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
+++ b/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
@@ -29,14 +29,12 @@ module.exports = class UniversalDocumentPlugin {
       this.insertScript = options.insertScript;
     }
 
-    this.isMultiple = options.isMultiple;
     this.documentPath = options.path;
     this.command = options.command;
   }
 
   apply(compiler) {
     const config = compiler.options;
-    const isMultiple = this.isMultiple;
     const absoluteDocumentPath = path.resolve(config.context, this.documentPath);
     const publicPath = this.publicPath ? this.publicPath : config.output.publicPath;
 
@@ -188,8 +186,8 @@ function loadDocument(content, insertScript) {
  * @param {*} publicPath 
  */
 function getAssetsForPage(files, publicPath) {
-  const jsFiles = files.filter(v => ~v.indexOf('.js'));
-  const cssFiles = files.filter(v => ~v.indexOf('.css'));
+  const jsFiles = files.filter(v => /\.js$/i.test(v));
+  const cssFiles = files.filter(v => /\.css$/i.test(v));
 
   return {
     scripts: jsFiles.map(script => publicPath + script),

--- a/packages/build-plugin-rax-multi-pages/src/index.js
+++ b/packages/build-plugin-rax-multi-pages/src/index.js
@@ -25,13 +25,6 @@ module.exports = ({ context, onGetWebpackConfig, getValue, setValue, onHook }) =
       }
 
       setEntry(config, context, entries, 'web');
-
-      config.plugin('document').tap(args => {
-        return [{
-          ...args[0],
-          isMultiple: true,
-        }];
-      });
     });
   }
 

--- a/packages/rax-generator/package.json
+++ b/packages/rax-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-generator",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Rax template generator.",
   "main": "src/index.js",
   "keywords": [

--- a/packages/rax-generator/src/template/app/src/components/Logo/index.jsx.ejs
+++ b/packages/rax-generator/src/template/app/src/components/Logo/index.jsx.ejs
@@ -2,12 +2,12 @@
 import { createElement } from '<%_ if (useReact) { -%>react<%_ } else { -%>rax<%_ } -%>';
 import Image from 'rax-image';
 
-import styles from './index.css';
+import './index.css';
 
 export default (props) => {
   return (
     <Image
-      style={styles.logo}
+      className='logo'
       source={{
         uri: '//gw.alicdn.com/tfs/TB1MRC_cvb2gK0jSZK9XXaEgFXa-1701-1535.png',
       }}

--- a/packages/rax-generator/src/template/app/src/pages/Home/index.jsx.ejs
+++ b/packages/rax-generator/src/template/app/src/pages/Home/index.jsx.ejs
@@ -4,7 +4,7 @@ import { createElement<%_ if (useFaaS) { -%>, useState, useEffect<%_ } -%> } fro
 import View from 'rax-view';
 import Text from 'rax-text';
 
-import styles from './index.css';
+import './index.css';
 
 import Logo from '../../components/Logo';
 
@@ -24,14 +24,14 @@ export default function Home() {
 <%_ } -%>
 
   return (
-    <View style={styles.home}>
+    <View className='home'>
       <Logo />
-      <Text style={styles.title}>Welcome to Your Rax App</Text>
+      <Text className='title'>Welcome to Your Rax App</Text>
       <%_ if (useFaaS) { -%>
-      <Text style={styles.info}>Current user: {account}</Text>
+      <Text className='info'>Current user: {account}</Text>
       <%_ } -%>
-      <Text style={styles.info}>More information about Rax</Text>
-      <Text style={styles.info}>Visit https://rax.js.org</Text>
+      <Text className='info'>More information about Rax</Text>
+      <Text className='info'>Visit https://rax.js.org</Text>
     </View>
   );
 }

--- a/packages/rax-generator/src/template/app/src/pages/Home/index.jsx.ejs
+++ b/packages/rax-generator/src/template/app/src/pages/Home/index.jsx.ejs
@@ -24,7 +24,7 @@ export default function Home() {
 <%_ } -%>
 
   return (
-    <View className='home'>
+    <View className='home'><%# className can work correctly whether `inlineStyle` is `true` or `false` %>
       <Logo />
       <Text className='title'>Welcome to Your Rax App</Text>
       <%_ if (useFaaS) { -%>


### PR DESCRIPTION
仅在构建产物有 css 文件的时候，向 document 透出 style 路径