### PR TITLE
Feat update multi pages version

### DIFF
--- a/packages/build-plugin-rax-multi-pages/package.json
+++ b/packages/build-plugin-rax-multi-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-multi-pages",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "rax app base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",


### PR DESCRIPTION
由于之前有 build-plugin-mulit-pages 的部分改动没有发布版本，https://github.com/raxjs/rax-scripts/pull/152 顺带发布了之前的提交，涉及到 document 改动的 breakchange，所以升级大版本

回滚方案
https://github.com/raxjs/rax-scripts/pull/152 发布的 0.1.5 已经回滚、tnpm 已同步

影响范围
0.1.5 版本会对 "build-plugin-rax-app": "^0.1.0" 的老业务产生影响，用户需要手动修改并升级 document
对最新创建的工程无影响
