### PR TITLE
feat(miniapp): support disable regenerator in babel config

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -4,7 +4,9 @@ const getAppConfig = require('./getAppConfig');
 const setEntry = require('./setEntry');
 
 module.exports = (context, target) => {
-  const config = getWebpackBase(context);
+  const config = getWebpackBase(context, {
+    disableRegenerator: true
+  });
 
   const appConfig = getAppConfig(context);
   setEntry(config, context, appConfig.routes);

--- a/packages/rax-compile-config/package.json
+++ b/packages/rax-compile-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-compile-config",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "rax app base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-compile-config/src/getBabelConfig.js
+++ b/packages/rax-compile-config/src/getBabelConfig.js
@@ -10,7 +10,7 @@ let logOnce = true;
 
 module.exports = (userOptions = {}) => {
   const options = Object.assign({}, defaultOptions, userOptions);
-  const { styleSheet, disableJSXPlus, custom = {}, isSSR } = options;
+  const { styleSheet, disableJSXPlus, custom = {}, isSSR, disableRegenerator = false } = options;
 
   const baseConfig = {
     presets: [
@@ -45,7 +45,7 @@ module.exports = (userOptions = {}) => {
         {
           'corejs': false,
           'helpers': false,
-          'regenerator': true,
+          'regenerator': !disableRegenerator,
           'useESModules': false,
         },
       ],


### PR DESCRIPTION
小程序运行时方案沿用了默认的 babel 编译配置，会引入 regenerator-runtime 用于处理 async/await 函数。但是 regenerator-runtime 中使用的 `new Function(...)` 语法出于安全问题在小程序框架中被禁用，同时小程序目前已支持 async/await，无需引入 polyfill。因此增加配置用于关闭 @babel/plugin-transform-runtime 中 regenerator 设置。