### PR TITLE
Feat support publicPath use relative path

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/src/build.js
+++ b/packages/build-plugin-rax-app/src/build.js
@@ -31,7 +31,7 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options
         // Update css file path
         if (config.plugins.get('minicss')) {
           config.plugin('minicss').tap((args) => args.map((arg) => {
-            if (typeof arg === 'object' && arg.filename === 'web/[name].css') {
+            if (typeof arg === 'object' && arg.filename === `${target}/[name].css`) {
               return Object.assign({}, arg, { filename: '[name].css' });
             }
             return arg;

--- a/packages/build-plugin-rax-app/src/build.js
+++ b/packages/build-plugin-rax-app/src/build.js
@@ -4,7 +4,7 @@ const consoleClear = require('console-clear');
 const { handleWebpackErr } = require('rax-compile-config');
 
 const getMpOuput = require('./config/miniapp/getOutputPath');
-const { WEB, WEEX, NODE, MINIAPP, KRAKEN, WECHAT_MINIPROGRAM } = require('./constants');
+const { WEB, WEEX, MINIAPP, KRAKEN, WECHAT_MINIPROGRAM } = require('./constants');
 
 module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options = {}) => {
   const { targets = [] } = options;
@@ -31,7 +31,7 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options
         if (config.plugins.get('minicss')) {
           config.plugin('minicss').tap((args) => args.map((arg) => {
             if (typeof arg === 'object' && arg.filename === 'web/[name].css') {
-              return Object.assign(arg, {filename: '[name].css'});
+              return Object.assign(arg, { filename: '[name].css' });
             }
             return arg;
           }));

--- a/packages/build-plugin-rax-app/src/build.js
+++ b/packages/build-plugin-rax-app/src/build.js
@@ -16,6 +16,9 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options
     // Change webpack outputPath from  'xx/build'      to 'xx/build/web'
     // Change source file's name from  'web/[name].js' to '[name].js'
     if (config.output.get('publicPath') === './') {
+      // Update output path
+      config.output.path(path.resolve(config.output.get('path'), WEB));
+
       // Update css file path
       if (config.plugins.get('minicss')) {
         config.plugin('minicss').tap((args) => args.map((arg) => {
@@ -25,8 +28,8 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options
           return arg;
         }));
       }
+
       // Update js file path
-      config.output.path(path.resolve(config.output.get('path'), WEB));
       config.output.filename('[name].js');
     }
   });

--- a/packages/build-plugin-rax-app/src/build.js
+++ b/packages/build-plugin-rax-app/src/build.js
@@ -21,6 +21,7 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options
     onGetWebpackConfig(target, (config) => {
       // Change webpack outputPath from  'xx/build'            to `xx/build/${target}`
       // Change source file's name from  `${target}/[name].js` to '[name].js'
+      // After the above changes, all the asset paths are relative to the entry file (like index.html).
       const publicPath = config.output.get('publicPath');
       if (publicPath.startsWith('.')) {
         config.output.publicPath(publicPath.endsWith('/') ? publicPath : `${publicPath}/`);
@@ -31,7 +32,7 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, onHook }, options
         if (config.plugins.get('minicss')) {
           config.plugin('minicss').tap((args) => args.map((arg) => {
             if (typeof arg === 'object' && arg.filename === 'web/[name].css') {
-              return Object.assign(arg, { filename: '[name].css' });
+              return Object.assign({}, arg, { filename: '[name].css' });
             }
             return arg;
           }));

--- a/packages/build-plugin-rax-app/src/config/processRelativePublicPath.js
+++ b/packages/build-plugin-rax-app/src/config/processRelativePublicPath.js
@@ -1,0 +1,15 @@
+const path = require('path');
+
+// Support publicPath use relative path (Called in build script).
+module.exports = (target, config) => {
+  // Change webpack outputPath from  'xx/build'            to `xx/build/${target}`
+  // Change source file's name from  `${target}/[name].js` to '[name].js'
+  // After the above changes, all the asset paths are relative to the entry file (like index.html).
+  const publicPath = config.output.get('publicPath');
+  if (publicPath.startsWith('.')) {
+    config.output.publicPath(publicPath.endsWith('/') ? publicPath : `${publicPath}/`);
+    // Update output path and filename
+    config.output.path(path.resolve(config.output.get('path'), target));
+    config.output.filename('[name].js');
+  }
+};

--- a/packages/build-plugin-rax-app/src/config/user/keys/inlineStyle.js
+++ b/packages/build-plugin-rax-app/src/config/user/keys/inlineStyle.js
@@ -18,7 +18,8 @@ module.exports = {
   defaultValue: true,
   validation: 'boolean',
   configWebpack: (config, value, context) => {
-    const { taskName } = context;
+    const { userConfig, taskName } = context;
+    const { publicPath } = userConfig;
 
     setCSSRule(config.module.rule('css').test(/\.css?$/), context, value);
     setCSSRule(config.module.rule('less').test(/\.less?$/), context, value);
@@ -40,7 +41,7 @@ module.exports = {
 
       config.plugin('minicss')
         .use(MiniCssExtractPlugin, [{
-          filename: `${taskName}/[name].css`,
+          filename: `${publicPath.startsWith('.') ? '' : `${taskName}/`}[name].css`,
         }]);
     }
   },
@@ -110,7 +111,7 @@ function setCSSRule(configRule, context, value) {
         .oneOf('normal')
         .use('css')
         .loader(require.resolve('css-loader'))
-      // reference: https://github.com/webpack-contrib/css-loader/tree/v2.1.1#localidentname
+        // reference: https://github.com/webpack-contrib/css-loader/tree/v2.1.1#localidentname
         .options(
           modules ? {
             importLoaders: 2,

--- a/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
+++ b/packages/build-plugin-rax-app/src/plugins/UniversalDocumentPlugin.js
@@ -193,7 +193,9 @@ function getAssetsForPage(files, publicPath) {
   const cssFiles = files.filter(v => /\.css$/i.test(v));
 
   return {
-    scripts: jsFiles.map(script => publicPath + script),
-    styles: cssFiles.map(style => publicPath + style),
+    // Support publicPath use relative path.
+    // Change MPA 'pageName/index.js' to 'index.js', when use relative path.
+    scripts: jsFiles.map(script => publicPath + (publicPath.startsWith('.') ? path.basename(script) : script)),
+    styles: cssFiles.map(style => publicPath + (publicPath.startsWith('.') ? path.basename(style) : style)),
   };
 }

--- a/packages/build-plugin-rax-multi-pages/package.json
+++ b/packages/build-plugin-rax-multi-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-multi-pages",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "rax app base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",


### PR DESCRIPTION
Support publicPath use relative path.

For example:
Set publicPath './', make Web App serving the same build from different paths.
It will make all the asset paths are relative to index.html.
User can be able to move their app anywhere without having to rebuild it.

```json
{
  "publicPath": "./"
}
```
