### PR TITLE
Chore/jsxplus tips

### DIFF
--- a/packages/rax-babel-config/package.json
+++ b/packages/rax-babel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-babel-config",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "rax base babel config",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-babel-config/src/index.js
+++ b/packages/rax-babel-config/src/index.js
@@ -27,9 +27,9 @@ module.exports = (userOptions = {}) => {
           targets: isNode ? {
             node: '8',
           } : {
-              chrome: '49',
-              ios: '8',
-            },
+            chrome: '49',
+            ios: '8',
+          },
           loose: true,
           modules: 'auto',
           include: [

--- a/packages/rax-babel-config/src/index.js
+++ b/packages/rax-babel-config/src/index.js
@@ -27,9 +27,9 @@ module.exports = (userOptions = {}) => {
           targets: isNode ? {
             node: '8',
           } : {
-            chrome: '49',
-            ios: '8',
-          },
+              chrome: '49',
+              ios: '8',
+            },
           loose: true,
           modules: 'auto',
           include: [
@@ -105,7 +105,7 @@ module.exports = (userOptions = {}) => {
     });
 
     if (logOnce) {
-      console.log(chalk.green('[JSX+] Stynax enabled.'));
+      console.log(chalk.green('JSX+ enabled, documentation: https://rax.js.org/docs/guide/jsxplus'));
       logOnce = false;
     }
   }

--- a/packages/rax-compile-config/package.json
+++ b/packages/rax-compile-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-compile-config",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "rax app base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-compile-config/src/getBabelConfig.js
+++ b/packages/rax-compile-config/src/getBabelConfig.js
@@ -21,9 +21,9 @@ module.exports = (userOptions = {}) => {
           targets: isSSR ? {
             node: '8',
           } : {
-            chrome: '49',
-            ios: '8',
-          },
+              chrome: '49',
+              ios: '8',
+            },
           loose: true,
           modules: 'auto',
           include: [
@@ -99,7 +99,7 @@ module.exports = (userOptions = {}) => {
     });
 
     if (logOnce) {
-      console.log(chalk.green('[JSX+] Stynax enabled.'));
+      console.log(chalk.green('JSX+ enabled, documentation: https://rax.js.org/docs/guide/jsxplus'));
       logOnce = false;
     }
   }

--- a/packages/rax-compile-config/src/getBabelConfig.js
+++ b/packages/rax-compile-config/src/getBabelConfig.js
@@ -21,9 +21,9 @@ module.exports = (userOptions = {}) => {
           targets: isSSR ? {
             node: '8',
           } : {
-              chrome: '49',
-              ios: '8',
-            },
+            chrome: '49',
+            ios: '8',
+          },
           loose: true,
           modules: 'auto',
           include: [


### PR DESCRIPTION
1. 更新 JSX Plus tips, 增加文档 (去掉了原先拼写错误)
2. rax-babel-config 版本更新到 0.1.0 做初始版本, 原先 0.0.1 对更新不友好, 新发版本一定会 break; 没查到 dependent, @yacheng 看下有没有其它包用到这个模块的

cc @imsobear

![image](https://user-images.githubusercontent.com/3922719/76381429-6e963680-6390-11ea-92bd-bb19e1809f9e.png)
