### PR TITLE
fix(plugin-rax-component): build lib when targets contain miniapp

### DIFF
--- a/packages/build-plugin-rax-component/package.json
+++ b/packages/build-plugin-rax-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-component",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "rax component base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/build-plugin-rax-component/src/buildLib.js
+++ b/packages/build-plugin-rax-component/src/buildLib.js
@@ -75,7 +75,6 @@ module.exports = async(api, options = {}) => {
         }
       };
       gulpCompile();
-
     }
   }
 };

--- a/packages/build-plugin-rax-component/src/buildLib.js
+++ b/packages/build-plugin-rax-component/src/buildLib.js
@@ -6,7 +6,7 @@ const gulpCompile = require('./gulp/compile');
 const gulpParams = require('./gulp/params');
 
 const jsx2mpBuilder = require('./config/miniapp/build');
-const { MINIAPP, WECHAT_MINIPROGRAM, WEB, WEEX, NODE } = require('./constants');
+const { MINIAPP, WECHAT_MINIPROGRAM } = require('./constants');
 
 module.exports = async(api, options = {}) => {
   const { context, log } = api;
@@ -19,7 +19,6 @@ module.exports = async(api, options = {}) => {
   const enableTypescript = fs.existsSync(path.join(rootDir, 'tsconfig.json'));
   const buildMiniapp = ~targets.indexOf(MINIAPP);
   const buildWechatMiniProgram = ~targets.indexOf(WECHAT_MINIPROGRAM);
-  const buildOtherPlatformBesidesMiniapp = targets.some(target => [WEB, WEEX, NODE].includes(target));
 
   const BUILD_DIR = path.resolve(rootDir, isDev ? devOutputDir : outputDir);
 
@@ -29,9 +28,6 @@ module.exports = async(api, options = {}) => {
   gulpParams.api = api;
   gulpParams.options = options;
 
-  if (buildOtherPlatformBesidesMiniapp) {
-    gulpCompile();
-  }
   if (buildMiniapp || buildWechatMiniProgram) {
     if (enableTypescript) {
       gulpParams.compileMiniappTS = true;
@@ -60,22 +56,26 @@ module.exports = async(api, options = {}) => {
       };
       gulpCompile();
     } else {
-      if (buildMiniapp) {
-        const config = options[MINIAPP] || {};
-        const result = await jsx2mpBuilder(context, null, config);
-        if (result.err) {
-          return result;
+      gulpParams.callback = async() => {
+        if (buildMiniapp) {
+          const config = options[MINIAPP] || {};
+          const result = await jsx2mpBuilder(context, null, config);
+          if (result.err) {
+            return result;
+          }
         }
-      }
-      if (buildWechatMiniProgram) {
-        const config = Object.assign({
-          platform: 'wechat',
-        }, options[WECHAT_MINIPROGRAM]);
-        const result = await jsx2mpBuilder(context, null, config);
-        if (result.err) {
-          return result;
+        if (buildWechatMiniProgram) {
+          const config = Object.assign({
+            platform: 'wechat',
+          }, options[WECHAT_MINIPROGRAM]);
+          const result = await jsx2mpBuilder(context, null, config);
+          if (result.err) {
+            return result;
+          }
         }
-      }
+      };
+      gulpCompile();
+
     }
   }
 };


### PR DESCRIPTION
- fix: gulpCompile is invoked twice when using typescript
- fix: can't find src/index.js when target only contains miniapp