### PR TITLE
feat: 新增spa devserver 入口访问自定义配置

### DIFF
--- a/packages/build-plugin-rax-app/src/config/web/setDev.js
+++ b/packages/build-plugin-rax-app/src/config/web/setDev.js
@@ -4,7 +4,7 @@ const path = require('path');
 // It is determined by webpack configuration, but not vary based on the operating system.
 const HTMLAssetPath = 'web/index.html';
 
-module.exports = (config, context, index) => {
+module.exports = (config, context, index, options) => {
   config.devServer.set('before', (app, devServer) => {
     const compiler = devServer.compiler.compilers[index];
     const httpResponseQueue = [];
@@ -23,8 +23,8 @@ module.exports = (config, context, index) => {
         res.send(fallbackHTMLContent);
       }
     });
-
-    app.get(/^\/?((?!\.(js|html|css|json)).)*$/, function(req, res) {
+    const reg = options.webEntry || /^\/?((?!\.(js|html|css|json)).)*$/
+    app.get(reg, function(req, res) {
       if (fallbackHTMLContent !== undefined) {
         res.send(fallbackHTMLContent);
       } else {

--- a/packages/build-plugin-rax-app/src/config/web/setDev.js
+++ b/packages/build-plugin-rax-app/src/config/web/setDev.js
@@ -23,7 +23,7 @@ module.exports = (config, context, index, options) => {
         res.send(fallbackHTMLContent);
       }
     });
-    const reg = options.webEntry || /^\/?((?!\.(js|html|css|json)).)*$/
+    const reg = options.webDevEntry || /^\/?((?!\.(js|html|css|json)).)*$/
     app.get(reg, function(req, res) {
       if (fallbackHTMLContent !== undefined) {
         res.send(fallbackHTMLContent);

--- a/packages/build-plugin-rax-app/src/dev.js
+++ b/packages/build-plugin-rax-app/src/dev.js
@@ -19,7 +19,7 @@ module.exports = ({ onGetWebpackConfig, registerTask, context, getValue, onHook 
 
     if (setDev) {
       onGetWebpackConfig(target, (config) => {
-        setDev(config, context, index);
+        setDev(config, context, index, options);
       });
     }
   });


### PR DESCRIPTION
原先这里/^\/?((?!\.(js|html|css|json)).)*$/这个正则匹配太范了，导致后面的插件想在 before.start.devServer hook做点 get请求相关的拦截功能全部失效，都被这个正则匹配走并返回了 html文档。因此希望这里新增一个自定义配置，让用户指定单页访问的入口，绕过正则。不太想在新增的插件配置 devServer.set('before') 覆盖已有的，感觉没什么必要