### PR TITLE
fix(jsx2mp-cli): use `workDirectory` instead of `process.cwd()`

### DIFF
--- a/packages/jsx2mp-cli/getWebpackConfig.js
+++ b/packages/jsx2mp-cli/getWebpackConfig.js
@@ -109,8 +109,6 @@ function addRelativePathPrefix(filepath) {
   return filepath[0] !== '.' ? `.${sep}${filepath}` : filepath;
 }
 
-const cwd = process.cwd();
-
 module.exports = (options = {}) => {
   let { entryPath, type, workDirectory, distDirectory, platform = 'ali', mode, constantDir, disableCopyNpm, turnOffSourceMap } = options;
   entryPath = addRelativePathPrefix(entryPath);
@@ -119,12 +117,12 @@ module.exports = (options = {}) => {
 
   const config = {
     mode: 'production', // Will be fast
-    entry: getEntry(type, cwd, relativeEntryFilePath, options),
+    entry: getEntry(type, workDirectory, relativeEntryFilePath, options),
     output: {
       path: distDirectory
     },
     target: 'node',
-    context: cwd,
+    context: workDirectory,
     module: {
       rules: [
         {

--- a/packages/jsx2mp-cli/package.json
+++ b/packages/jsx2mp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "BSD-3-Clause",
   "description": "A cli tool to transform Rax JSX based project to MiniApp.",
   "bin": {


### PR DESCRIPTION
use user-passed `workDirectory` parameter

1. workDirectory has been used to represent current working directory which can be changed by situation
2. current working directory not always be `process.cwd()`, for example, as a test case in `<project>/test/fixtures`