### PR TITLE
fix(jsx2mp): path error when requiring npm json file

### DIFF
--- a/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
+++ b/packages/jsx2mp-loader/src/babel-plugin-rename-import.js
@@ -1,4 +1,4 @@
-const { join, relative, dirname } = require('path');
+const { join, relative, dirname, extname } = require('path');
 const enhancedResolve = require('enhanced-resolve');
 const chalk = require('chalk');
 
@@ -36,7 +36,12 @@ module.exports = function visitor({ types: t }, options) {
 
     const rootNodeModulePath = join(rootContext, 'node_modules');
     const filePath = relative(dirname(distSourcePath), join(outputPath, 'npm', relative(rootNodeModulePath, target)));
-    return t.stringLiteral(normalizeNpmFileName(addRelativePathPrefix(normalizeOutputFilePath(filePath))));
+    let modifiedValue = normalizeNpmFileName(addRelativePathPrefix(normalizeOutputFilePath(filePath)));
+    // json file will be transformed to js file
+    if (extname(value) === '.json') {
+      modifiedValue = removeExt(modifiedValue);
+    }
+    return t.stringLiteral(modifiedValue);
   };
 
   // In WeChat MiniProgram, `require` can't get index file if index is omitted


### PR DESCRIPTION
- fix the path error like the following:

```js
var legacyMap = require("entities/maps/legacy.json");
```
Since json file wille be tranformed to js file, hence the require path should change.

Wrong: 

```js
var legacyMap = require("../../_entities_1.1.2_entities/maps/legacy.json");
```

Correct: 

```js
var legacyMap = require("../../_entities_1.1.2_entities/maps/legacy");
```