### PR TITLE
fix: extra text node in ssr

### DIFF
--- a/packages/build-plugin-rax-component/package.json
+++ b/packages/build-plugin-rax-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-component",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "rax component base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/build-plugin-rax-component/src/config/node/getDev.js
+++ b/packages/build-plugin-rax-component/src/config/node/getDev.js
@@ -106,9 +106,7 @@ module.exports = (context, options) => {
               ${style}
             </head>
             <body style="padding: 0;margin: 0">
-              <div id="root">
-                ${content}
-              </div>
+              <div id="root">${content}</div>
               ${srcipt}
             </body>
           </html>`;


### PR DESCRIPTION
原有方式引入了换行符，Client hydrate 的时候会拿正常节点与换行符进行比对，导致错误