### PR TITLE
feat: use miniapp babel presets insteadof babel plugins

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "4.6.5",
+  "version": "4.6.6-5",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {
@@ -71,6 +71,6 @@
     "webpack-bundle-analyzer": "^3.4.1",
     "webpack-chain": "^6.0.0",
     "webpack-sources": "^1.3.0",
-    "rax-miniapp-babel-plugins": "^0.1.0"
+    "rax-miniapp-babel-plugins": "0.1.2-0"
   }
 }

--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -39,10 +39,15 @@ module.exports = (context, target, options) => {
   config.module.rule('jsx')
     .use('babel')
     .tap(options => {
-      options.plugins = [...getMiniAppBabelPlugins({
-        usingComponents,
-        nativeLifeCycleMap
-      }), ...options.plugins];
+      options.presets = [
+        ...options.presets,
+        {
+          plugins: getMiniAppBabelPlugins({
+            usingComponents,
+            nativeLifeCycleMap
+          })
+        }
+      ];
       return options;
     });
 

--- a/packages/rax-miniapp-babel-plugins/package.json
+++ b/packages/rax-miniapp-babel-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-babel-plugins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "rax miniapp babel plugins",
   "main": "src/index.js",
   "repository": {

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-native-lifecycle.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-native-lifecycle.js
@@ -5,7 +5,7 @@ module.exports = function visitor({ types: t }, { nativeLifeCycleMap }) {
   return {
     visitor: {
       CallExpression(path, { filename, file: { code } }) {
-        const pagePath = getPagePath(filename, nativeLifeCycleMap);
+        const pagePath = getPagePath(filename);
         if (pagePath) {
           const nativeLifeCycle = nativeLifeCycleMap[pagePath];
           if (t.isIdentifier(path.node.callee, {

--- a/packages/rax-miniapp-babel-plugins/src/utils/getPagePath.js
+++ b/packages/rax-miniapp-babel-plugins/src/utils/getPagePath.js
@@ -3,17 +3,11 @@ const getFilePath = require('./getFilePath');
 
 /**
  * @param {string} filename - Current handled file name
- * @param {object} nativeLifeCycleMap - Native lifecycle map
  * @return {string|undefined}
  */
-module.exports = function(filename, nativeLifeCycleMap) {
+module.exports = function(filename) {
   const nodeModulesReg = new RegExp(`${sep}node_modules${sep}`);
   if (!nodeModulesReg.exec(filename)) {
-    const filePath = getFilePath(filename);
-    if (nativeLifeCycleMap[filePath]) {
-      // Reset page lifecycle map
-      nativeLifeCycleMap[filePath] = {};
-    }
-    return filePath;
+    return getFilePath(filename);
   }
 };


### PR DESCRIPTION
由于 babel plugin 的并行机制，预编译直接使用 babel plugins 的方式会导致，假如用户通过自定义 babel plugin 修改文件，miniapp babel plugins 拿到的还是用户修改前的源文件，从而影响了用户的定制能力。