### PR TITLE
feat(miniapp): add render control to custom component

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/package.json
+++ b/packages/rax-miniapp-runtime-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-runtime-webpack-plugin",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A webpack plugin for miniapp runtime build",
   "main": "src/index.js",
   "keywords": [

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/custom-component.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/custom-component.js
@@ -41,7 +41,7 @@ module.exports = function(
     // custom-component/index.xml
     addFileToCompilation(compilation, {
       filename: `custom-component/index.${adapter[target].xml}`,
-      content: `<block ${adapter[target].directive}="{{ready}}">
+      content: `<block ${adapter[target].directive.if}="{{ready}}">
         ${
   names
     .map((key, index) => {

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/custom-component.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/custom-component.js
@@ -41,18 +41,22 @@ module.exports = function(
     // custom-component/index.xml
     addFileToCompilation(compilation, {
       filename: `custom-component/index.${adapter[target].xml}`,
-      content: names
-        .map((key, index) => {
-          const { props = [], events = [] } = customComponents[key];
-          return `<${key} ${adapter[target].directive.prefix}:${
-            index === 0 ? 'if' : 'elif'
-          }="{{name === '${key}'}}" id="{{id}}" class="{{className}}" style="{{style}}" ${props
-            .map((name) => `${name}="{{${name}}}"`)
-            .join(' ')} ${events
-            .map((name) => `${adapter[target].directive.event}${name}="on${name}"`)
-            .join(' ')}><slot/></${key}>`;
-        })
-        .join('\n'),
+      content: `<block ${adapter[target].directive}="{{ready}}">
+        ${
+  names
+    .map((key, index) => {
+      const { props = [], events = [] } = customComponents[key];
+      return `<${key} ${adapter[target].directive.prefix}:${
+        index === 0 ? 'if' : 'elif'
+      }="{{name === '${key}'}}" id="{{id}}" class="{{className}}" style="{{style}}" ${props
+        .map((name) => `${name}="{{${name}}}"`)
+        .join(' ')} ${events
+        .map((name) => `${adapter[target].directive.event}${name}="on${name}"`)
+        .join(' ')}><slot/></${key}>`;
+    })
+    .join('\n')
+}
+      </block>`,
       target,
       command,
     });

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/templates/ali-miniapp/custom-component.js.ejs
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/templates/ali-miniapp/custom-component.js.ejs
@@ -21,6 +21,9 @@ function checkComponentAttr({ props = [] }, name, domNode, destData, oldData) {
 }
 
 Component({
+  data: {
+    ready: false
+  },
   props: {
     name: ''
   },
@@ -28,6 +31,10 @@ Component({
     const nodeId = this.props['data-private-node-id'];
     const pageId = this.props['data-private-page-id'];
     const data = {};
+
+    if (!this.data.ready) {
+      data.ready = true;
+    }
 
     this.nodeId = nodeId;
     this.pageId = pageId;

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/templates/wechat-miniprogram/custom-component.js.ejs
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/templates/wechat-miniprogram/custom-component.js.ejs
@@ -21,6 +21,9 @@ function checkComponentAttr({ props = [] }, name, domNode, destData, oldData) {
 }
 
 Component({
+  data: {
+    ready: false
+  },
   properties: {
     name: {
       type: String,
@@ -34,6 +37,10 @@ Component({
     const nodeId = this.dataset.privateNodeId;
     const pageId = this.dataset.privatePageId;
     const data = {};
+
+    if (!this.data.ready) {
+      data.ready = true;
+    }
 
     this.nodeId = nodeId;
     this.pageId = pageId;


### PR DESCRIPTION
#### 背景
渲染原生自定义组件时，需要在父层构造的 `custom-component` `didMount` 时，读取开发者使用到的 `props`，再通过 `setData` 传递给目标组件，这会导致目标组件第一次渲染时拿不到 `props`。

#### 解法
父层组件通过 `ready` 控制目标组件渲染，使目标组件初次渲染和获取 `props` 是同步行为。