### PR TITLE
chore: compatible appx2.0 onReachBottom

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/package.json
+++ b/packages/rax-miniapp-runtime-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-runtime-webpack-plugin",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A webpack plugin for miniapp runtime build",
   "main": "src/index.js",
   "keywords": [

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/nativeLifeCycle.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/nativeLifeCycle.js
@@ -19,6 +19,10 @@ module.exports = {
     name: 'onPullIntercept',
     inEventsProps: false,
   },
+  onReachBottom: {
+    name: 'onReachBottom',
+    inEventsProps: false,
+  },
   onBack: {
     inEventsProps: true,
   },
@@ -41,9 +45,6 @@ module.exports = {
     inEventsProps: true,
   },
   onResize: {
-    inEventsProps: true,
-  },
-  onReachBottom: {
     inEventsProps: true,
   }
 };


### PR DESCRIPTION
In MiniApp appx2.0, `onReachBottom` can only be registered in config