### PR TITLE
fix: webpack load-json

### DIFF
--- a/packages/build-plugin-rax-app/src/config/miniapp/compile/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/compile/getBase.js
@@ -151,7 +151,6 @@ module.exports = (context, target, options = {}, onGetWebpackConfig) => {
   config.module
     .rule('json')
     .test(/\.json$/)
-    .type('javascript/auto')
     .use('script-loader')
     .loader(ScriptLoader)
     .options(loaderParams)

--- a/packages/build-plugin-rax-app/src/config/miniapp/compile/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/compile/getBase.js
@@ -151,6 +151,7 @@ module.exports = (context, target, options = {}, onGetWebpackConfig) => {
   config.module
     .rule('json')
     .test(/\.json$/)
+    .type('javascript/auto')
     .use('script-loader')
     .loader(ScriptLoader)
     .options(loaderParams)

--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -27,6 +27,7 @@ module.exports = (context, target, options) => {
   config.module
     .rule('json')
     .test(/\.json$/)
+    .type('javascript/auto')
     .use('json-loader')
     .loader(require.resolve('json-loader'));
 
@@ -92,3 +93,4 @@ module.exports = (context, target, options) => {
   config.devtool('inline-source-map');
   return config;
 };
+


### PR DESCRIPTION
json-loader 处理过的文件会变成 `module.exports = xxx` 的形式，而现在 webpack 又会自动 load json，所以如果要使用 json-loader 自定义加载 json 文件，则需要把 json 文件的 type 改成 `javascript/auto` 来避免 webpack 的 json 解析。