### PR TITLE
chore(miniapp): root node use custom component

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/element.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/element.js
@@ -1,5 +1,8 @@
+const ejs = require('ejs');
+const { MINIAPP } = require('../constants');
 const adapter = require('../adapter');
 const addFileToCompilation = require('../utils/addFileToCompilation');
+const getTemplate = require('../utils/getTemplate');
 
 function generateElementJS(compilation,
   { target, command, rootDir }) {
@@ -17,7 +20,9 @@ function generateElementTemplate(compilation,
   { target, command, rootDir }) {
   addFileToCompilation(compilation, {
     filename: `comp.${adapter[target].xml}`,
-    content: `<import src="./root.${adapter[target].xml}"/>
+    content: `${target !== MINIAPP ?
+      '<import src="./root.${adapter[target].xml}"/>' :
+      ejs.render(getTemplate(rootDir, 'root.xml', target))}
 
     <template is="{{r.behavior || 'element'}}" data="{{r: r, isComp: true}}" />`,
     target,
@@ -32,8 +37,8 @@ function generateElementJSON(compilation, useNativeComponent,
     content: `{
       "component": true,
       "usingComponents": {
-        ${useNativeComponent ? '"custom-component": "./custom-component/index",' : ''}
-        "element": "./comp"
+        ${useNativeComponent ? '"custom-component": "./custom-component/index"' : ''}
+        ${target !== MINIAPP ? ',"element": "./comp"' : ''}
       }
     }`,
     target,

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/element.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/element.js
@@ -3,6 +3,7 @@ const { MINIAPP } = require('../constants');
 const adapter = require('../adapter');
 const addFileToCompilation = require('../utils/addFileToCompilation');
 const getTemplate = require('../utils/getTemplate');
+const generateRootTmpl = require('./root');
 
 function generateElementJS(compilation,
   { target, command, rootDir }) {
@@ -18,13 +19,18 @@ function generateElementJS(compilation,
 
 function generateElementTemplate(compilation,
   { target, command, rootDir }) {
+  let content = '<template is="{{r.behavior || \'element\'}}" data="{{r: r, isComp: true}}" />';
+  if (target !== MINIAPP) {
+    generateRootTmpl(compilation,
+      { target, command, rootDir });
+    content = '<import src="./root.${adapter[target].xml}"/>' + content;
+  } else {
+    // In MiniApp, root.axml need be written into comp.axml
+    content = ejs.render(getTemplate(rootDir, 'root.xml', target)) + content;
+  }
   addFileToCompilation(compilation, {
     filename: `comp.${adapter[target].xml}`,
-    content: `${target !== MINIAPP ?
-      '<import src="./root.${adapter[target].xml}"/>' :
-      ejs.render(getTemplate(rootDir, 'root.xml', target))}
-
-    <template is="{{r.behavior || 'element'}}" data="{{r: r, isComp: true}}" />`,
+    content,
     target,
     command,
   });

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
@@ -215,12 +215,6 @@ class MiniAppRuntimePlugin {
         }
 
         if (target !== MINIAPP || useNativeComponent) {
-          // Generate root template xml
-          generateRootTemplate(compilation, {
-            target,
-            command,
-            rootDir,
-          });
           // Generate self loop element
           generateElementJS(compilation, {
             target,

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
@@ -215,7 +215,7 @@ class MiniAppRuntimePlugin {
           });
         }
 
-        if (target !== MINIAPP) {
+        if (target !== MINIAPP || useNativeComponent) {
           // Generate root template xml
           generateRootTemplate(compilation, {
             target,
@@ -238,7 +238,7 @@ class MiniAppRuntimePlugin {
             command,
             rootDir,
           });
-        } else if (!useNativeComponent) {
+        } else {
           // Only when there isn't native component, it need generate root template file
           // Generate root template xml
           generateRootTemplate(compilation, {


### PR DESCRIPTION
页面根节点通过自定义组件渲染，从而避免在使用到原生组件时，将 root.axml 每次都写入每个页面造成小程序体积过大