### PR TITLE
fix(miniapp): native page copy

### DIFF
--- a/packages/build-plugin-rax-app/src/config/miniapp/filterNativePages.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/filterNativePages.js
@@ -1,5 +1,5 @@
 const { existsSync, copySync } = require('fs-extra');
-const { dirname, join } = require('path');
+const { dirname, join, resolve } = require('path');
 const { getDepPath } = require('../pathHelper');
 const targetPlatformMap = require('./targetPlatformMap');
 
@@ -12,15 +12,14 @@ function isNativePage(filePath, target) {
   return existsSync(filePath + targetPlatformMap[target].tplExtension);
 }
 
-function copyNativePage(pageEntry, source, outputPath) {
-  copySync(dirname(pageEntry), join(outputPath, dirname(source)));
-}
-
-module.exports = (routes, { rootDir, target, outputPath }) => {
+module.exports = (routes, needCopyList, { rootDir, target, outputPath }) => {
   return routes.filter(({ source }) => {
     const pageEntry = getDepPath(rootDir, source);
     if (isNativePage(pageEntry, target)) {
-      copyNativePage(pageEntry, source, outputPath);
+      needCopyList.push({
+        from: dirname(pageEntry),
+        to: join(target, dirname(source))
+      });
       return false;
     }
     return true;

--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -1,6 +1,7 @@
 const MiniAppRuntimePlugin = require('rax-miniapp-runtime-webpack-plugin');
 const MiniAppConfigPlugin = require('rax-miniapp-config-webpack-plugin');
 const getMiniAppBabelPlugins = require('rax-miniapp-babel-plugins');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const getWebpackBase = require('../../getWebpackBase');
 const getAppConfig = require('../getAppConfig');
 const setEntry = require('./setEntry');
@@ -15,12 +16,14 @@ module.exports = (context, target, options) => {
   const usingComponents = {};
   // Native lifecycle map
   const nativeLifeCycleMap = {};
+  // Need Copy files or dir
+  const needCopyList = [];
 
   const config = getWebpackBase(context, {
     disableRegenerator: true
   }, target);
   const appConfig = getAppConfig(rootDir, target, nativeLifeCycleMap);
-  appConfig.routes = filterNativePages(appConfig.routes, { rootDir, target, outputPath });
+  appConfig.routes = filterNativePages(appConfig.routes, needCopyList, { rootDir, target, outputPath });
   setEntry(config, context, appConfig.routes);
 
   // Remove all app.json before it
@@ -89,9 +92,13 @@ module.exports = (context, target, options) => {
       usingComponents,
       nativeLifeCycleMap,
       rootDir,
-      command
+      command,
+      needCopyList
     }
   ]);
+
+  config.plugin('copyWebpackPlugin')
+    .use(CopyWebpackPlugin, [needCopyList]);
 
   config.devServer.writeToDisk(true).noInfo(true).inline(false);
   if (command === 'start') {

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
@@ -1,5 +1,5 @@
-const { resolve, relative, join } = require('path');
-const { readJsonSync, existsSync } = require('fs-extra');
+const { resolve, relative, join, dirname } = require('path');
+const { readJsonSync, existsSync, copyFileSync, lstatSync, ensureDirSync } = require('fs-extra');
 const { RawSource } = require('webpack-sources');
 const adjustCSS = require('./utils/adjustCSS');
 const { MINIAPP, VENDOR_CSS_FILE_NAME } = require('./constants');
@@ -165,6 +165,12 @@ class MiniAppRuntimePlugin {
           );
         });
 
+      // These files need be written in first render
+      if (isFirstRender) {
+        // render.js
+        generateRender(compilation, { target, command, rootDir });
+      }
+
       // Collect app.js
       if (isFirstRender || changedFiles.includes('/app.js' || '/app.ts')) {
         const commonAppJSFilePaths = compilation.entrypoints
@@ -186,11 +192,8 @@ class MiniAppRuntimePlugin {
         generateAppCSS(compilation, { target, command, rootDir });
       }
 
-      // These files need be written in first render or using native component state changes
+      // These files need be written in first render and using native component state changes
       if (isFirstRender || useNativeComponentCountChanged) {
-        // render.js
-        generateRender(compilation, { target, command, rootDir });
-
         // Config js
         generateConfig(compilation, usingComponents, {
           target,


### PR DESCRIPTION
`build` 模式下，原生页面的复制操作是在 webpack 清空 `build` 目录之前执行的，导致产物中原生页面丢失