### PR TITLE
Fix memory leak when render document

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "v5.0.4",
+  "version": "5.0.4",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "5.0.3",
+  "version": "v5.0.4",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/src/config/user/keys/stats.js
+++ b/packages/build-plugin-rax-app/src/config/user/keys/stats.js
@@ -5,7 +5,7 @@ module.exports = {
     const { command } = context;
 
     // disable webpack stats log
-    if (command === 'start' && !value) {
+    if (command === 'start' && value) {
       process.env.DISABLE_STATS = true;
     }
   },

--- a/packages/build-plugin-rax-ssr/package.json
+++ b/packages/build-plugin-rax-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-ssr",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "rax ssr plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/build-plugin-rax-ssr/src/ssr/setDev.js
+++ b/packages/build-plugin-rax-ssr/src/ssr/setDev.js
@@ -30,6 +30,9 @@ module.exports = (config, context) => {
     route.componentPath = path.join(distDir, filename.replace('[name]', entryName));
   });
 
+  // enable inline soucremap for get error stack
+  config.devtool('eval-cheap-source-map');
+
   config.devServer.hot(false);
 
   // There can only be one `before` config, this config will overwrite `before` config in web plugin.

--- a/packages/error-stack-tracey/package.json
+++ b/packages/error-stack-tracey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "error-stack-tracey",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Trace error stack with sourcemap",
   "main": "src/index.js",
   "license": "BSD-3-Clause",

--- a/packages/error-stack-tracey/src/index.js
+++ b/packages/error-stack-tracey/src/index.js
@@ -2,10 +2,14 @@ const ErrorStackParser = require('error-stack-parser');
 const SourceMap = require('source-map');
 
 async function parse(error, bundleContent) {
-  const sourcemap = getSourceMap(bundleContent);
-  const consumer = await new SourceMap.SourceMapConsumer(sourcemap);
   const originalErrorStack = ErrorStackParser.parse(error);
+  const sourcemap = getSourceMap(bundleContent);
 
+  if (!sourcemap) {
+    return originalErrorStack;
+  }
+
+  const consumer = await new SourceMap.SourceMapConsumer(sourcemap);
   const mergedErrorStack = originalErrorStack.map((err, index) => {
     const errorFrame = originalErrorStack[index];
     const originalSourcePosition = consumer.originalPositionFor({

--- a/packages/error-stack-tracey/src/index.js
+++ b/packages/error-stack-tracey/src/index.js
@@ -57,14 +57,20 @@ function getSourceMap(bundleContent) {
   const rawSourceMap = bundleContent.substr(readStart + 1);
   const headSlice = rawSourceMap.slice(0, 100);
 
+  // no sourcemap
   if (headSlice.indexOf('sourceMappingURL') < 0) {
-    return null;
+    return;
   }
 
   const base64KeyWord = 'base64,';
   const base64Start = rawSourceMap.indexOf(base64KeyWord);
-  const base64 = rawSourceMap.substr(base64Start + base64KeyWord.length);
 
+  // !inlineSoureMap
+  if (base64Start < 0) {
+    return;
+  }
+
+  const base64 = rawSourceMap.substr(base64Start + base64KeyWord.length);
   const sourceMapString = Buffer.from(base64, 'base64').toString('utf-8');
   return JSON.parse(sourceMapString);
 }


### PR DESCRIPTION
1. 修复本地 dev 阶段内存泄漏问题
2. 错误日志结构化兼容无 sourcemap 的情况
3. 修复 stats 没有正常关闭的问题

约 50 次修改后，内存的占用情况对比

修改前

![image](https://user-images.githubusercontent.com/1303018/87413824-6891ba00-c5fd-11ea-94c0-60bba99f66e3.png)

修改后

![image](https://user-images.githubusercontent.com/1303018/87413838-6def0480-c5fd-11ea-92ff-aa4dfa3af44f.png)

原因为渲染 Document，使用了 Webpack 构建过程中的产物，会导致内存无法释放。修复方式：先减少不必要的渲染逻辑，后续考虑 Document 不走 Webpack 构建。