### PR TITLE
feat: support ignore plugin check

### DIFF
--- a/packages/build-plugin-rax-app/src/index.js
+++ b/packages/build-plugin-rax-app/src/index.js
@@ -5,7 +5,9 @@ const build = require('./build');
 const dev = require('./dev');
 
 const pluginApp = (api, options = {}) => {
-  enterCheck(api, options);
+  if (typeof options.enterCheck === 'boolean' ? options.enterCheck : true) {
+    enterCheck(api, options);
+  }
 
   api.setValue('targets', options.targets);
   api.setValue('appType', options.type || 'spa');


### PR DESCRIPTION

- build-plugin-rax-app 插件默认做了 enterCheck 检查，即要求在 build.json 中配置顺序为第一个，在 raxjs 中将会内置 build-plugin-rax-app 插件，在这种场景下不需要开启检查，因此新增 enterCheck 参数用于配置