### PR TITLE
fix(miniapp): config in disorder

### DIFF
--- a/packages/rax-miniapp-config-webpack-plugin/package.json
+++ b/packages/rax-miniapp-config-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-config-webpack-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "miniapp config webpack plugin",
   "main": "src/index.js",
   "scripts": {

--- a/packages/rax-miniapp-config-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-config-webpack-plugin/src/index.js
@@ -31,11 +31,10 @@ module.exports = class MiniAppConfigPlugin {
         safeWriteFile(join(outputPath, target === 'quickapp' ? 'appConfig.js' : 'app.config.js'), `module.exports = ${JSON.stringify(appConfig, null, 2)}`);
       }
       // Transform page config
-      config.pages.map((page, index) => {
-        const route = appConfig.routes[index];
+      appConfig.routes.map((route) => {
         if (route && route.window) {
           ensureDirSync(outputPath);
-          safeWriteFile(join(outputPath, page + '.json'), adaptConfig(route.window, 'window', target), true);
+          safeWriteFile(join(outputPath, route.source + '.json'), adaptConfig(route.window, 'window', target), true);
         }
       });
 


### PR DESCRIPTION
当项目中使用原生页面的时候，生成的页面配置会错乱