### PR TITLE
fix(build-plugin-rax-app):rax-app project error

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -1,6 +1,8 @@
 const MiniAppRuntimePlugin = require('rax-miniapp-runtime-webpack-plugin');
 const MiniAppConfigPlugin = require('rax-miniapp-config-webpack-plugin');
 const getMiniAppBabelPlugins = require('rax-miniapp-babel-plugins');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+
 const getWebpackBase = require('../../getWebpackBase');
 const getAppConfig = require('../getAppConfig');
 const setEntry = require('./setEntry');

--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -108,11 +108,8 @@ module.exports = (context, target, options) => {
     }
   ]);
 
-  config.plugin('copyWebpackPlugin')
-    .tap(args => {
-      args[0] = args[0].concat(needCopyList);
-      return args;
-    });
+  config.plugin('copyWebpackPluginForRuntimeMiniapp')
+    .use(CopyWebpackPlugin, [needCopyList]);
 
   config.devServer.writeToDisk(true).noInfo(true).inline(false);
   if (command === 'start') {

--- a/packages/build-plugin-rax-app/src/config/pathHelper.js
+++ b/packages/build-plugin-rax-app/src/config/pathHelper.js
@@ -122,7 +122,7 @@ function isNativePage(filePath, target) {
  */
 function removeExt(filePath) {
   const lastDot = filePath.lastIndexOf('.');
-  return filePath.slice(0, lastDot);
+  return lastDot === -1 ? filePath : filePath.slice(0, lastDot);
 }
 
 module.exports = {

--- a/packages/rax-webpack-config/package.json
+++ b/packages/rax-webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-webpack-config",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "rax base webpack config",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-webpack-config/src/index.js
+++ b/packages/rax-webpack-config/src/index.js
@@ -34,10 +34,6 @@ module.exports = (context) => {
     },
   ]);
 
-  config.resolve.modules
-    .add('node_modules')
-    .add(path.join(rootDir, 'node_modules'));
-
   config.resolve.extensions.merge(['.js', '.json', '.jsx', '.ts', '.tsx', '.html']);
   config.module
     .rule('jsx')


### PR DESCRIPTION
- [x] 在小程序运行时 webpack 配置中使用单独的 copy 插件，防止 base webpack config 中未调用，出现报错
- [x] 增加去除文件后缀函数 removeExt 的容错性
- [x] 去除 rax-webpack-config 中新增的 node_modules 寻址逻辑，确保按照默认寻址逻辑处理依赖