### PR TITLE
feat: support set sock info

### DIFF
--- a/packages/rax-compile-config/package.json
+++ b/packages/rax-compile-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-compile-config",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "rax app base plugins",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-compile-config/src/hmr/webpackHotDevClient.entry.js
+++ b/packages/rax-compile-config/src/hmr/webpackHotDevClient.entry.js
@@ -7,9 +7,11 @@ let wsProtocol = 'ws';
 if (window.location.protocol === 'https:') {
   wsProtocol = 'wss';
 }
-const wsUrl = `${wsProtocol}://${window.location.hostname}:${window.location.port}/sockjs-node/websocket`;
+const wsHost = process.env.SOCK_HOST || window.location.hostname;
+const wsPort = process.env.SOCK_PORT || window.location.port;
+
+const wsUrl = `${wsProtocol}://${wsHost}:${wsPort}/sockjs-node/websocket`;
 // Connect to WebpackDevServer via a socket.
-console.log('The development server at', wsUrl);
 const connection = new WebSocket(wsUrl);
 
 // Unlike WebpackDevServer client, we won't try to reconnect

--- a/packages/rax-compile-config/src/hmr/webpackHotDevClient.entry.js
+++ b/packages/rax-compile-config/src/hmr/webpackHotDevClient.entry.js
@@ -3,7 +3,6 @@
 const stripAnsi = require('strip-ansi');
 const formatWebpackMessages = require('./formatWebpackMessages');
 
-
 let wsProtocol = 'ws';
 if (process.env.SOCK_PROTOCOL) {
   wsProtocol = process.env.SOCK_PROTOCOL;

--- a/packages/rax-compile-config/src/hmr/webpackHotDevClient.entry.js
+++ b/packages/rax-compile-config/src/hmr/webpackHotDevClient.entry.js
@@ -3,10 +3,14 @@
 const stripAnsi = require('strip-ansi');
 const formatWebpackMessages = require('./formatWebpackMessages');
 
+
 let wsProtocol = 'ws';
-if (window.location.protocol === 'https:') {
+if (process.env.SOCK_PROTOCOL) {
+  wsProtocol = process.env.SOCK_PROTOCOL;
+} else if (window.location.protocol === 'https:') {
   wsProtocol = 'wss';
 }
+
 const wsHost = process.env.SOCK_HOST || window.location.hostname;
 const wsPort = process.env.SOCK_PORT || window.location.port;
 


### PR DESCRIPTION
支持通过 `process.env.SOCK_PORT`/`process.env.SOCK_PATH`/`process.env.SOCK_PROTOCOL` 设置 sock 配置