### PR TITLE
feat(miniapp): add runtimeDependencies to control runtime components use

### DIFF
--- a/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
+++ b/packages/build-plugin-rax-app/src/config/miniapp/runtime/getBase.js
@@ -13,6 +13,7 @@ const { getPlatformExtensions } = require('../../pathHelper');
 
 module.exports = (context, target, options) => {
   const { rootDir, command } = context;
+  const { runtimeDependencies = [] } = options[target] || {};
   const outputPath = getMiniAppOutput(context, { target });
 
   // Using components
@@ -50,7 +51,8 @@ module.exports = (context, target, options) => {
             nativeLifeCycleMap,
             target,
             rootDir,
-            usingPlugins
+            usingPlugins,
+            runtimeDependencies
           })
         }
       ];

--- a/packages/rax-miniapp-babel-plugins/src/index.js
+++ b/packages/rax-miniapp-babel-plugins/src/index.js
@@ -1,4 +1,4 @@
-module.exports = function({ usingComponents, nativeLifeCycleMap, target, rootDir, usingPlugins }) {
+module.exports = function({ usingComponents, nativeLifeCycleMap, target, rootDir, usingPlugins, runtimeDependencies }) {
   return [
     require.resolve('./plugins/babel-plugin-remove-Function'),
     require.resolve('./plugins/babel-plugin-external-module'),
@@ -13,7 +13,8 @@ module.exports = function({ usingComponents, nativeLifeCycleMap, target, rootDir
       {
         usingComponents,
         target,
-        rootDir
+        rootDir,
+        runtimeDependencies
       }
     ],
     [

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
@@ -33,13 +33,15 @@ const targetMap = {
  * @param {string} rootDir project root dir
  * @param {string} source module name
  * @param {string} target miniapp platform
+ * @param {string[]} runtimeDependencies components that use runtime implementation
+ *
  */
-function getNpmSourcePath(rootDir, source, target) {
+function getNpmSourcePath(rootDir, source, target, runtimeDependencies) {
   const modulePath = resolve(rootDir, 'node_modules', source);
   try {
     const pkgConfig = readJSONSync(join(modulePath, 'package.json'));
     const miniappConfig = pkgConfig.miniappConfig;
-    if (!miniappConfig || baseComponents.includes(source)) {
+    if (!miniappConfig || baseComponents.includes(source) || isInRuntimeDependencies(source, runtimeDependencies)) {
       return source;
     }
     const miniappEntry = target === 'miniapp' ? miniappConfig.main : miniappConfig[`main:${targetMap[target]}`];
@@ -53,10 +55,10 @@ function getNpmSourcePath(rootDir, source, target) {
   }
 };
 
-function getTmplPath(source, rootDir, dirName, target) {
+function getTmplPath(source, rootDir, dirName, target, runtimeDependencies) {
   // If it's a npm module, keep source origin value, otherwise use absolute path
   const isNpm = !RELATIVE_COMPONENTS_REG.test(source);
-  let filePath = isNpm ? getNpmSourcePath(rootDir, source, target) : resolve(dirName, source);
+  let filePath = isNpm ? getNpmSourcePath(rootDir, source, target, runtimeDependencies) : resolve(dirName, source);
   const absPath = isNpm ? resolve(rootDir, 'node_modules', filePath) : filePath;
   if (!existsSync(`${absPath}.${extMap[target]}`)) return false;
   if (target === 'wechat-miniprogram') {
@@ -66,10 +68,35 @@ function getTmplPath(source, rootDir, dirName, target) {
   return isNpm ? filePath : `.${filePath.replace(resolve(rootDir, 'src'), '')}`;
 }
 
+/**
+ * Judge if the str is regexp
+ * @param {string} str
+ */
+function isRegExpStr(str) {
+  return str[0] === '/' && str[str.length - 1] === '/'
+}
+
+/**
+ *
+ * @param {string} dependency
+ * @param {string[]} runtimeDependencies
+ */
+function isInRuntimeDependencies(dependency, runtimeDependencies = []) {
+  for (let runtimeDependency of runtimeDependencies) {
+    if (isRegExpStr(runtimeDependency)) {
+      const reg = new RegExp(runtimeDependency.slice(1, -1));
+      if (reg.test(dependency)) return true;
+    } else if (runtimeDependency === dependency) {
+       return true;
+    }
+  }
+  return false;
+}
+
 module.exports = function visitor(
   { types: t },
-  { usingComponents, target, rootDir }
-) {
+  { usingComponents, target, rootDir, runtimeDependencies }
+  ) {
   // Collect imported dependencies
   const nativeComponents = {};
   const nativeComponentsNameMap = new Map();
@@ -83,7 +110,7 @@ module.exports = function visitor(
           const { specifiers, source } = path.node;
           if (Array.isArray(specifiers) && t.isStringLiteral(source)) {
             const dirName = dirname(filename);
-            const filePath = getTmplPath(source.value, rootDir, dirName, target);
+            const filePath = getTmplPath(source.value, rootDir, dirName, target, runtimeDependencies);
             if (filePath) {
               if (!scanedPageMap[filename]) {
                 scanedPageMap[filename] = true;

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
@@ -73,7 +73,7 @@ function getTmplPath(source, rootDir, dirName, target, runtimeDependencies) {
  * @param {string} str
  */
 function isRegExpStr(str) {
-  return str[0] === '/' && str[str.length - 1] === '/'
+  return str[0] === '/' && str[str.length - 1] === '/';
 }
 
 /**
@@ -87,7 +87,7 @@ function isInRuntimeDependencies(dependency, runtimeDependencies = []) {
       const reg = new RegExp(runtimeDependency.slice(1, -1));
       if (reg.test(dependency)) return true;
     } else if (runtimeDependency === dependency) {
-       return true;
+      return true;
     }
   }
   return false;
@@ -96,7 +96,7 @@ function isInRuntimeDependencies(dependency, runtimeDependencies = []) {
 module.exports = function visitor(
   { types: t },
   { usingComponents, target, rootDir, runtimeDependencies }
-  ) {
+) {
   // Collect imported dependencies
   const nativeComponents = {};
   const nativeComponentsNameMap = new Map();

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
@@ -86,9 +86,7 @@ function isInRuntimeDependencies(dependency, runtimeDependencies = []) {
     if (isRegExpStr(runtimeDependency)) {
       const reg = new RegExp(runtimeDependency.slice(1, -1));
       if (reg.test(dependency)) return true;
-    } else if (runtimeDependency === dependency) {
-      return true;
-    }
+    } else if (runtimeDependency === dependency) return true;
   }
   return false;
 }


### PR DESCRIPTION
- [x] Rax 运行时小程序项目中使用到 Rax 组件工程产出的组件时，优先使用其编译时产物。现提供 runtimeDependencies 参数，用于配置使用其 Web 链路（即运行时链路）的产物而不使用编译时产物的组件。runtimeDependencies 为数组，支持使用正则表达式或字符串匹配组件包名