### PR TITLE
chore: mpa support autoRender option

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -59,7 +59,7 @@
     "rax-miniapp-babel-plugins": "^0.1.0",
     "rax-miniapp-config-webpack-plugin": "^1.0.1",
     "rax-miniapp-runtime-webpack-plugin": "^1.0.0",
-    "rax-multi-pages-settings": "^0.1.1-0",
+    "rax-multi-pages-settings": "^0.1.1",
     "rax-quickapp-webpack-plugin": "^1.0.0",
     "rax-server-renderer": "^1.0.0",
     "rax-webpack-config": "^0.1.0",

--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "5.2.1",
+  "version": "5.2.2-0",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {
@@ -59,7 +59,7 @@
     "rax-miniapp-babel-plugins": "^0.1.0",
     "rax-miniapp-config-webpack-plugin": "^1.0.1",
     "rax-miniapp-runtime-webpack-plugin": "^1.0.0",
-    "rax-multi-pages-settings": "^0.1.0",
+    "rax-multi-pages-settings": "^0.1.1-0",
     "rax-quickapp-webpack-plugin": "^1.0.0",
     "rax-server-renderer": "^1.0.0",
     "rax-webpack-config": "^0.1.0",

--- a/packages/build-plugin-rax-app/src/index.js
+++ b/packages/build-plugin-rax-app/src/index.js
@@ -35,7 +35,7 @@ function enterCheck(api, options) {
 
   const firstPluginName = Array.isArray(plugins[0]) ? plugins[0][0] : plugins[0];
 
-  if (firstPluginName !== 'build-plugin-rax-app') {
+  if (!/build-plugin-rax-app/.test(firstPluginName)) {
     errMsg = 'build-plugin-rax-app must be the first plugin, please check the order of plugins';
     hasError = true;
   }

--- a/packages/rax-multi-pages-settings/package.json
+++ b/packages/rax-multi-pages-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-multi-pages-settings",
-  "version": "0.1.0",
+  "version": "0.1.1-0",
   "description": "build-scripts config settings about rax mpa",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/packages/rax-multi-pages-settings/src/setConfig.js
+++ b/packages/rax-multi-pages-settings/src/setConfig.js
@@ -20,14 +20,14 @@ module.exports = (config, context, targets, currentTarget) => {
 
   config.entryPoints.clear();
 
-  entries.forEach(({ entryName, source }) => {
+  entries.forEach(({ entryName, source, ...otherOptions }) => {
     const entryConfig = config.entry(entryName);
     if (isDev && process.env.RAX_SSR !== 'true') {
       entryConfig.add(hmrClient);
     }
 
     const pageEntry = getDepPath(rootDir, source);
-    entryConfig.add(`${MulitPageLoader}?type=${currentTarget}!${pageEntry}`);
+    entryConfig.add(otherOptions.disableWrapperRender ? pageEntry : `${MulitPageLoader}?type=${currentTarget}&source=${source}!${pageEntry}`);
   });
 
   if (currentTarget === 'web') {

--- a/packages/rax-multi-pages-settings/src/setConfig.js
+++ b/packages/rax-multi-pages-settings/src/setConfig.js
@@ -20,14 +20,14 @@ module.exports = (config, context, targets, currentTarget) => {
 
   config.entryPoints.clear();
 
-  entries.forEach(({ entryName, source, ...otherOptions }) => {
+  entries.forEach(({ entryName, source, autoRender }) => {
     const entryConfig = config.entry(entryName);
     if (isDev && process.env.RAX_SSR !== 'true') {
       entryConfig.add(hmrClient);
     }
 
     const pageEntry = getDepPath(rootDir, source);
-    entryConfig.add(otherOptions.disableWrapperRender ? pageEntry : `${MulitPageLoader}?type=${currentTarget}&source=${source}!${pageEntry}`);
+    entryConfig.add(autoRender === false ? pageEntry : `${MulitPageLoader}?type=${currentTarget}&source=${source}!${pageEntry}`);
   });
 
   if (currentTarget === 'web') {


### PR DESCRIPTION
build-plugin-rax-app@5.2.3-0

```diff
{
  "routes": [
    {
      "path": "home",
      "source": "pages/home/index",
+      "autoRender": false  // default true
    },
    {
      "path": "home-pc",
      "source": "pages/home/index-pc"
    }
  ],
  "hydrate": true
}
```

加了这个选项之后，MPA 情况下工程不会自动包 render()，render 逻辑业务自己负责：

```js
import { createElement, render } from 'rax';
import Driver from 'universal-driver';

const Home = () => {
  return <>home</>;
}

render(<Home />, document.getElementById('root'), {
  driver: Driver
});
```


