### PR TITLE
fix: regeneratorRuntime path remove error

### DIFF
--- a/packages/rax-miniapp-babel-plugins/package.json
+++ b/packages/rax-miniapp-babel-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-babel-plugins",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "rax miniapp babel plugins",
   "main": "src/index.js",
   "repository": {

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-remove-Function.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-remove-Function.js
@@ -14,7 +14,9 @@ module.exports = function visitor() {
         ) {
           // Remove `Function('r', 'regeneratorRuntime = r')(runtime)`
           // Because Alibaba Miniapp doesn't allow use `Function`
-          path.parentPath.remove();
+          try {
+            path.parentPath.remove();
+          } catch(err) {}
         }
       }
     }

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-remove-Function.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-remove-Function.js
@@ -16,7 +16,7 @@ module.exports = function visitor() {
           // Because Alibaba Miniapp doesn't allow use `Function`
           try {
             path.parentPath.remove();
-          } catch(err) {}
+          } catch (err) {}
         }
       }
     }

--- a/packages/rax-miniapp-babel-plugins/src/utils/handleComponentAST.js
+++ b/packages/rax-miniapp-babel-plugins/src/utils/handleComponentAST.js
@@ -1,4 +1,4 @@
-const getTagName = require("./getTagName");
+const getTagName = require('./getTagName');
 
 function collectComponentAttr(components, t) {
   return (innerPath) => {
@@ -47,7 +47,7 @@ function collectUsings(
       // Insert a tag
       componentInfo.node.attributes.push(
         t.jsxAttribute(
-          t.jsxIdentifier("__native"),
+          t.jsxIdentifier('__native'),
           t.jsxExpressionContainer(t.booleanLiteral(true))
         )
       );
@@ -72,7 +72,7 @@ function collectUsings(
       componentsNameMap.set(tagName, replacedTagName);
       // Use const Custom = 'c90589c' replace import Custom from '../public/xxx or plugin://...'
       path.replaceWith(
-        t.VariableDeclaration("const", [
+        t.VariableDeclaration('const', [
           t.VariableDeclarator(
             t.identifier(tagName),
             t.stringLiteral(replacedTagName)


### PR DESCRIPTION
- 解决 babel 插件在移除相关节点时冲突的操作
- 原生自定义组件和插件添加 `__native` 属性作为区分