### PR TITLE
fix: inlineStyle false add wrong babel plugin

### DIFF
--- a/packages/build-plugin-rax-app/package.json
+++ b/packages/build-plugin-rax-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "build-plugin-rax-app",
-  "version": "5.2.9",
+  "version": "5.2.10",
   "description": "rax app base plugins",
   "main": "src/index.js",
   "scripts": {

--- a/packages/build-plugin-rax-app/src/config/getWebpackBase.js
+++ b/packages/build-plugin-rax-app/src/config/getWebpackBase.js
@@ -3,13 +3,15 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const getWebpackBase = require('rax-webpack-config');
 const getBabelConfig = require('rax-babel-config');
+const { MINIAPP, WECHAT_MINIPROGRAM, BYTEDANCE_MICROAPP } = require('../constants');
 
 module.exports = (context, options = {}, target) => {
-  const { rootDir, command } = context;
+  const { rootDir, command, userConfig = {} } = context;
   const { processBar } = options;
+  const { inlineStyle = true } = userConfig;
 
   const babelConfig = getBabelConfig({
-    styleSheet: true,
+    styleSheet: inlineStyle,
     ...options,
   });
 
@@ -66,13 +68,17 @@ module.exports = (context, options = {}, target) => {
     .use('platform')
     .loader(require.resolve('rax-compile-config/src/platformLoader'));
 
+   const copyWebpackPluginPatterns = [];
+  if ([MINIAPP, WECHAT_MINIPROGRAM, BYTEDANCE_MICROAPP].includes(target)) {
+    copyWebpackPluginPatterns.push({ from: 'src/public', to: `public` })
+  } else {
+    copyWebpackPluginPatterns.push({ from: 'src/public', to: `${target}/public` })
 
-  const copyWebpackPluginPatterns = [{ from: 'src/public', to: `${target}/public` }];
-
-  if (command === 'start') {
-    // MiniApp usually use `./public/xxx.png` as file src.
-    // Dev Server start with '/'. if you want to use './public/xxx.png', should copy public to the root.
-    copyWebpackPluginPatterns.push({ from: 'src/public', to: 'public' });
+    if (command === 'start') {
+      // MiniApp usually use `./public/xxx.png` as file src.
+      // Dev Server start with '/'. if you want to use './public/xxx.png', should copy public to the root.
+      copyWebpackPluginPatterns.push({ from: 'src/public', to: 'public' });
+    }
   }
 
   if (target && fs.existsSync(path.resolve(rootDir, 'src/public'))) {

--- a/packages/build-plugin-rax-app/src/config/getWebpackBase.js
+++ b/packages/build-plugin-rax-app/src/config/getWebpackBase.js
@@ -68,11 +68,11 @@ module.exports = (context, options = {}, target) => {
     .use('platform')
     .loader(require.resolve('rax-compile-config/src/platformLoader'));
 
-   const copyWebpackPluginPatterns = [];
+  const copyWebpackPluginPatterns = [];
   if ([MINIAPP, WECHAT_MINIPROGRAM, BYTEDANCE_MICROAPP].includes(target)) {
-    copyWebpackPluginPatterns.push({ from: 'src/public', to: `public` })
+    copyWebpackPluginPatterns.push({ from: 'src/public', to: 'public' });
   } else {
-    copyWebpackPluginPatterns.push({ from: 'src/public', to: `${target}/public` })
+    copyWebpackPluginPatterns.push({ from: 'src/public', to: `${target}/public` });
 
     if (command === 'start') {
       // MiniApp usually use `./public/xxx.png` as file src.

--- a/packages/build-plugin-rax-app/src/config/getWebpackBase.js
+++ b/packages/build-plugin-rax-app/src/config/getWebpackBase.js
@@ -69,16 +69,12 @@ module.exports = (context, options = {}, target) => {
     .loader(require.resolve('rax-compile-config/src/platformLoader'));
 
   const copyWebpackPluginPatterns = [];
-  if ([MINIAPP, WECHAT_MINIPROGRAM, BYTEDANCE_MICROAPP].includes(target)) {
+  if ([MINIAPP, WECHAT_MINIPROGRAM, BYTEDANCE_MICROAPP].includes(target) || command === 'start') {
+    // MiniApp usually use `./public/xxx.png` as file src.
+    // Dev Server start with '/'. if you want to use './public/xxx.png', should copy public to the root.
     copyWebpackPluginPatterns.push({ from: 'src/public', to: 'public' });
   } else {
     copyWebpackPluginPatterns.push({ from: 'src/public', to: `${target}/public` });
-
-    if (command === 'start') {
-      // MiniApp usually use `./public/xxx.png` as file src.
-      // Dev Server start with '/'. if you want to use './public/xxx.png', should copy public to the root.
-      copyWebpackPluginPatterns.push({ from: 'src/public', to: 'public' });
-    }
   }
 
   if (target && fs.existsSync(path.resolve(rootDir, 'src/public'))) {

--- a/packages/build-plugin-rax-app/src/config/user/keys/inlineStyle.js
+++ b/packages/build-plugin-rax-app/src/config/user/keys/inlineStyle.js
@@ -68,8 +68,6 @@ module.exports = {
         filename = '';
       }
 
-      console.log('filename', filename);
-
       config.plugin('minicss')
         .use(MiniCssExtractPlugin, [{
           filename,


### PR DESCRIPTION
- 修复小程序生成多余的 `public` 文件夹
- 修复 `inlineStyle: false` 的情况下，通过 `npm` 包的形式引入多个 `css` 文件报错的问题