### PR TITLE
fix: 修复依赖抽离之后找不到对应 node_modules 的问题

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/render.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/render.js
@@ -1,13 +1,11 @@
-const { resolve } = require('path');
+const path = require('path');
 const { readFileSync } = require('fs-extra');
 const adapter = require('../adapter');
 const addFileToCompilation = require('../utils/addFileToCompilation');
 
 module.exports = function(compilation, { target, command, rootDir }) {
-  const sourceNpmFile = resolve(
-    process.cwd(),
-    'node_modules',
-    'miniapp-render',
+  const sourceNpmFile = path.join(
+    require.resolve('miniapp-render').replace('/dist/ali/index.js', ''),
     'dist',
     adapter[target].fileName,
     command === 'build' ? 'index.min.js' : 'index.js'


### PR DESCRIPTION
我们想要把一些公共依赖，比如 rax 的脚手架抽离到我们自己的脚手架里面，这样就不用每个 rax 组件工程都把这些依赖给安装一遍，但是改的这处代码是从工程运行的地方获取 node_modules 目录，在项目工程里面获取不到，所以修改